### PR TITLE
U4ID: combine tunnel declaration into add command

### DIFF
--- a/kernel-include/linux/rtnetlink.h
+++ b/kernel-include/linux/rtnetlink.h
@@ -289,7 +289,7 @@ enum rtattr_type_t {
 	RTA_PREFSRC,
 	RTA_METRICS,
 	RTA_MULTIPATH,
-	RTA_PROTOINFO, /* no longer used */
+	RTA_PROTOINFO, /* Only used by XIA */
 	RTA_FLOW,
 	RTA_CACHEINFO,
 	RTA_SESSION, /* no longer used */

--- a/kernel-include/net/xia_u4id.h
+++ b/kernel-include/net/xia_u4id.h
@@ -1,0 +1,15 @@
+#ifndef _NET_XIA_U4ID_H
+#define _NET_XIA_U4ID_H
+
+#ifndef __KERNEL__
+#include <stdbool.h>
+#endif
+
+#define XIDTYPE_U4ID            (__cpu_to_be32(0x16))
+
+struct local_u4id_info {
+	bool	tunnel;
+	bool	checksum_disabled;
+};
+
+#endif	/* _NET_XIA_U4ID_H */


### PR DESCRIPTION
xip u4id can now specify which local entry should be a tunnel source, and whether checksumming is enabled or disabled on that socket.
